### PR TITLE
Correct media types

### DIFF
--- a/HTTPArchive/utils.py
+++ b/HTTPArchive/utils.py
@@ -70,6 +70,7 @@ def pretty_type(mime_typ, ext):
         "svg",
         "ico",
         "bmp",
+        "tiff",
         "avif",
         "jxl",
         "heic",
@@ -98,6 +99,8 @@ def pretty_type(mime_typ, ext):
 
 
 def get_format(pretty_typ, mime_typ, ext):
+    mime_typ = mime_typ.lower()
+    
     if "image" == pretty_typ:
         # Test mime_typ first, as "better" type can be
         # returned with same extension
@@ -130,6 +133,7 @@ def get_format(pretty_typ, mime_typ, ext):
             "svg",
             "ico",
             "bmp",
+            "tiff",
             "avif",
             "jxl",
             "heic",


### PR DESCRIPTION
Some image CDNs return a different format rather than the extension, so I think relying on the extension could be incorrect. Additionally I'm seeing a lot of `text/html` (often for 302s or 404s).

We should only fallback to the extension where the mime type is either 1) explicitly not set or 2) set to something generic like `application/octet-stream` or `binary/octet-stream`.

This means failed images requests will still have the "image" `type` (since they were image requests), but now no longer return the file extension as the `format` (since the responses are not formatted as images).

Additionally I've added some more media types (`bmp`, `tiff`, `quicktime`, `mp2t`, `m2ts`, `ogv`).

And also I noticed we were doing a `lower()` when identifying the file time so those were often missing categorisations for sites that returned mixed or uppercase content-types.