### PR TITLE
Keep plain-string custom metrics

### DIFF
--- a/HTTPArchive/httparchive.py
+++ b/HTTPArchive/httparchive.py
@@ -129,12 +129,8 @@ def get_custom_metrics(page, wptid, max_size=None):
             try:
                 value = json.loads(value)
             except ValueError:
-                logging.warning(
-                    "ValueError: Unable to parse custom metric %s as JSON for %s",
-                    metric,
-                    wptid,
-                )
-                continue
+                # Value is a plain string, not JSON-encoded. Keep it as-is.
+                pass
             except RecursionError:
                 logging.warning(
                     "RecursionError: Unable to parse custom metric %s as JSON for %s",


### PR DESCRIPTION
This pull request makes a minor change to the error handling in the `get_custom_metrics` function. Specifically, it no longer logs a warning when a custom metric value cannot be parsed as JSON and instead simply keeps the value as a plain string.